### PR TITLE
feat: create accp hosted zone from existing account stage

### DIFF
--- a/src/AccountStage.ts
+++ b/src/AccountStage.ts
@@ -34,6 +34,7 @@ export class AccountStage extends Stage {
     if (props.deployDnsSecKmsKey) {
       new DnsSecStack(this, 'dnssec-stack', {
         env: { region: 'us-east-1' },
+        enableDnsSec: props.enableDnsSec,
       });
     }
 

--- a/src/CspNijmegenStage.ts
+++ b/src/CspNijmegenStage.ts
@@ -22,6 +22,7 @@ export class CspNijmegenStage extends Stage {
     // KMS key for dnssec (must be in us-east-1)
     new DnsSecStack(this, 'dnssec-stack', {
       env: { region: 'us-east-1' },
+      enableDnsSec: false,
     });
   }
 }

--- a/src/TempAuthAccpStage.ts
+++ b/src/TempAuthAccpStage.ts
@@ -74,6 +74,13 @@ class TempAuthAccpStack extends Stack {
       values: ['v=spf1 include:amazonses.com ~all'],
     });
 
+    // DS
+    // new route53.DsRecord(this, 'ds-1', {
+    //  zone,
+    //  recordName: 'mijn.accp.csp-nijmegen.nl',
+    //  values: ['52561 13 2 90CF3C35FDDC30AF42FB4BCCDCCB1123500050D70F1D4886D6DE25502F3BC50A'],
+    // });
+
     // MX
     new route53.MxRecord(this, 'mx-1', {
       zone,

--- a/src/TempAuthAccpStage.ts
+++ b/src/TempAuthAccpStage.ts
@@ -20,13 +20,9 @@ class TempAuthAccpStack extends Stack {
   constructor(scope: Construct, id: string, props?: StackProps) {
     super(scope, id, props);
 
-    // Use secondary imports to find the newly auth-accp.csp-nijmegen.nl hosted zone
-    var ssmZoneId = Statics.envRootHostedZoneId + '/second';
-    var ssmZoneName = Statics.envRootHostedZoneName + '/second';
-
     // Import parameters
-    const zoneId = SSM.StringParameter.valueForStringParameter(this, ssmZoneId);
-    const zoneName = SSM.StringParameter.valueForStringParameter(this, ssmZoneName);
+    const zoneId = SSM.StringParameter.valueForStringParameter(this, Statics.envRootHostedZoneId);
+    const zoneName = SSM.StringParameter.valueForStringParameter(this, Statics.envRootHostedZoneName);
 
     // Import the hosted zone
     const zone = route53.HostedZone.fromHostedZoneAttributes(this, 'auth-accp', {
@@ -76,13 +72,6 @@ class TempAuthAccpStack extends Stack {
       zone,
       recordName: 'mail.accp.csp-nijmegen.nl',
       values: ['v=spf1 include:amazonses.com ~all'],
-    });
-
-    // DS
-    new route53.DsRecord(this, 'ds-1', {
-      zone,
-      recordName: 'mijn.accp.csp-nijmegen.nl',
-      values: ['52561', '13', '2', '90CF3C35FDDC30AF42FB4BCCDCCB1123500050D70F1D4886D6DE25502F3BC50A'],
     });
 
     // MX

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -3,7 +3,7 @@ import { AwsSolutionsChecks } from 'cdk-nag';
 import { CspNijmegenStack } from '../src/CspNijmegenStack';
 import { DnsSecStack } from '../src/DnsSecStack';
 import { DnsStack } from '../src/DnsStack';
-
+import { PipelineStack } from '../src/PipelineStack';
 
 const env = {
   account: '123',
@@ -14,6 +14,14 @@ test('Snapshot', () => {
 
   const app = new App();
 
+  const pipeline = new PipelineStack(app, 'pipeline-stack', {
+    env,
+    acceptance: env,
+    branchName: 'production',
+    deployment: env,
+    production: env,
+    sandbox: env,
+  });
 
   const dnsstack = new DnsStack(app, 'dns-stack', {
     productionAccount: env.account,
@@ -23,7 +31,7 @@ test('Snapshot', () => {
   });
 
   const dnssecstack = new DnsSecStack(app, 'dnssec-stack', {
-
+    enableDnsSec: true,
   });
 
   const cspStack = new CspNijmegenStack(app, 'csp-stack', {
@@ -32,11 +40,13 @@ test('Snapshot', () => {
   });
 
   // Nag
+  Aspects.of(pipeline).add(new AwsSolutionsChecks({ verbose: true }));
   Aspects.of(dnsstack).add(new AwsSolutionsChecks({ verbose: true }));
   Aspects.of(dnssecstack).add(new AwsSolutionsChecks({ verbose: true }));
   Aspects.of(cspStack).add(new AwsSolutionsChecks({ verbose: true }));
 
   // Snapshot
+  expect(app.synth().getStackArtifact(pipeline.artifactId).template).toMatchSnapshot();
   expect(app.synth().getStackArtifact(dnsstack.artifactId).template).toMatchSnapshot();
   expect(app.synth().getStackArtifact(dnssecstack.artifactId).template).toMatchSnapshot();
   expect(app.synth().getStackArtifact(cspStack.artifactId).template).toMatchSnapshot();


### PR DESCRIPTION
In deze stap:
- Maak een 2e accp.csp-nijmegen.nl aan
- Voeg hier de bestaande dns records aan toe (behalve DS, A en AAAA records)
- Bereid DNSSEC voor op deze hosted zone (met bestaande KMS key)