### PR TITLE
feat: enable dnssec for accp hosted zone clone

### DIFF
--- a/src/PipelineStack.ts
+++ b/src/PipelineStack.ts
@@ -48,8 +48,8 @@ export class PipelineStack extends Stack {
       env: props.acceptance,
       name: 'accp',
       cspRootEnvironment: props.production,
-      deployDnsStack: true, // accp.csp-nijmegen.nl is still managed in webformulieren (however parameters are not used yet so we can safely create this zone as long as it is not registered in csp-nijmegen.nl, see prop registerInCspNijmegenRoot)
-      enableDnsSec: false, // Enable after property above is deployed (small steps)
+      deployDnsStack: true, // accp.csp-nijmegen.nl is still managed in webformulieren (however we have a unregistered in csp-nijmegen.nl copy now)
+      enableDnsSec: true, 
       deployDnsSecKmsKey: true,
       registerInCspNijmegenRoot: false, // Can be enabled after other zone removed from webformulieren (Note that a policy in csp stack should be added before!)
     });

--- a/src/PipelineStack.ts
+++ b/src/PipelineStack.ts
@@ -49,7 +49,7 @@ export class PipelineStack extends Stack {
       name: 'accp',
       cspRootEnvironment: props.production,
       deployDnsStack: true, // accp.csp-nijmegen.nl is still managed in webformulieren (however we have a unregistered in csp-nijmegen.nl copy now)
-      enableDnsSec: true, 
+      enableDnsSec: true,
       deployDnsSecKmsKey: true,
       registerInCspNijmegenRoot: false, // Can be enabled after other zone removed from webformulieren (Note that a policy in csp stack should be added before!)
     });

--- a/src/TempAuthAccpStage.ts
+++ b/src/TempAuthAccpStage.ts
@@ -75,11 +75,11 @@ class TempAuthAccpStack extends Stack {
     });
 
     // DS
-    // new route53.DsRecord(this, 'ds-1', {
-    //  zone,
-    //  recordName: 'mijn.accp.csp-nijmegen.nl',
-    //  values: ['52561 13 2 90CF3C35FDDC30AF42FB4BCCDCCB1123500050D70F1D4886D6DE25502F3BC50A'],
-    // });
+    new route53.DsRecord(this, 'ds-1', {
+      zone,
+      recordName: 'mijn.accp.csp-nijmegen.nl',
+      values: ['52561 13 2 90CF3C35FDDC30AF42FB4BCCDCCB1123500050D70F1D4886D6DE25502F3BC50A'],
+    });
 
     // MX
     new route53.MxRecord(this, 'mx-1', {


### PR DESCRIPTION
- Enable DNSSEC for hosted zone copy
- Deploy the missing DS record