### PR TITLE
feat: prepare for deploying a AccountStage to auth-prod

### DIFF
--- a/src/AccountStage.ts
+++ b/src/AccountStage.ts
@@ -35,6 +35,7 @@ export class AccountStage extends Stage {
       new DnsSecStack(this, 'dnssec-stack', {
         env: { region: 'us-east-1' },
         enableDnsSec: props.enableDnsSec,
+        useSecondaryParameter: false,
       });
     }
 

--- a/src/CspNijmegenStack.ts
+++ b/src/CspNijmegenStack.ts
@@ -29,16 +29,6 @@ export class CspNijmegenStack extends cdk.Stack {
       zoneName: rootZoneName,
     });
 
-    // Store in parameters for other projects to find this hostedzone
-    new SSM.StringParameter(this, 'csp-sub-hostedzone-id', {
-      stringValue: cspNijmegenZone.hostedZoneId,
-      parameterName: Statics.envRootHostedZoneId,
-    });
-    new SSM.StringParameter(this, 'csp-sub-hostedzone-name', {
-      stringValue: cspNijmegenZone.zoneName,
-      parameterName: Statics.envRootHostedZoneName,
-    });
-
     // Register the relegation role
     const arn = cspNijmegenZone.hostedZoneArn;
     this.enableDelegationToAccount(arn, props.sandbox, 'sandbox');

--- a/src/CspNijmegenStage.ts
+++ b/src/CspNijmegenStage.ts
@@ -23,6 +23,7 @@ export class CspNijmegenStage extends Stage {
     new DnsSecStack(this, 'dnssec-stack', {
       env: { region: 'us-east-1' },
       enableDnsSec: false,
+      useSecondaryParameter: true,
     });
   }
 }

--- a/src/DnsSecStack.ts
+++ b/src/DnsSecStack.ts
@@ -10,6 +10,9 @@ export interface DnsSecStackProps extends cdk.StackProps {
    * set this to true to import the account hosted zone and enable dnssec on it
    */
   enableDnsSec: boolean;
+
+  //Temp secondary parameter
+  useSecondaryParameter: boolean;
 }
 
 export class DnsSecStack extends cdk.Stack {
@@ -29,6 +32,13 @@ export class DnsSecStack extends cdk.Stack {
       stringValue: dnssecKey.keyArn,
       parameterName: Statics.accountDnsSecKmsKey,
     });
+
+    if (props.useSecondaryParameter) { // TODO remove after prod.csp-nijmegen.nl is in production
+      new SSM.StringParameter(this, 'account-dnssec-kms-key-arn-moving', {
+        stringValue: dnssecKey.keyArn,
+        parameterName: Statics.accountDnsSecKmsKey + '/moving',
+      });
+    }
 
     if (props.enableDnsSec) {
       this.enableDnsSecForAccountRootZone(dnssecKey.keyArn);

--- a/src/Statics.ts
+++ b/src/Statics.ts
@@ -10,6 +10,12 @@ export class Statics {
   static readonly envRootHostedZoneId: string = '/gemeente-nijmegen/account/hostedzone/id';
   static readonly envRootHostedZoneName: string = '/gemeente-nijmegen/account/hostedzone/name';
 
+  // csp-nijmegen.nl hosted zone
+  static readonly cspNijmegenHostedZonePath: string = '/gemeente-nijmegen/csp/hostedzone';
+  static readonly cspNijmegenHostedZoneId: string = '/gemeente-nijmegen/csp/hostedzone/id';
+  static readonly cspNijmegenHostedZoneName: string = '/gemeente-nijmegen/csp/hostedzone/name';
+
+
   // The KSM key parameters for each account
   static readonly accountDnsSecKmsKey: string = '/gemeente-nijmegen/account/dnssec/kmskey/arn';
   static readonly accountDnsSecKmsKeyAlias: string = 'gemeente-nijmegen/dnssec/default';

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -32,6 +32,7 @@ test('Snapshot', () => {
 
   const dnssecstack = new DnsSecStack(app, 'dnssec-stack', {
     enableDnsSec: true,
+    useSecondaryParameter: false,
   });
 
   const cspStack = new CspNijmegenStack(app, 'csp-stack', {


### PR DESCRIPTION
- Voeg een 2e parameter met arn voor kms key voor DNSSEC toe (omdat de key verhuist wordt naar een andere stack)
- Verwijder parameters naar csp hosted zone in auth-prod (worden niet gebruikt en zullen straks worden aangemaakt door een AccountStage) 