### PR TITLE
feat: add stack dependency and rename kms key alias for auth-prod

### DIFF
--- a/src/CspNijmegenStack.ts
+++ b/src/CspNijmegenStack.ts
@@ -3,14 +3,9 @@ import { aws_ssm as SSM, aws_route53 as Route53, Tags, aws_iam as IAM, Environme
 import { Construct } from 'constructs';
 import { Statics } from './Statics';
 
-
-export interface CspNijmegenStackProps extends cdk.StackProps {
-
-}
-
 export class CspNijmegenStack extends cdk.Stack {
 
-  constructor(scope: Construct, id: string, props: CspNijmegenStackProps) {
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
 
     Tags.of(this).add('cdkManaged', 'yes');

--- a/src/DnsSecStack.ts
+++ b/src/DnsSecStack.ts
@@ -24,7 +24,11 @@ export class DnsSecStack extends cdk.Stack {
     Tags.of(this).add('Project', Statics.projectName);
 
     // Create the (expensive $) key
-    const dnssecKey = this.addDNSSecKey(Statics.accountDnsSecKmsKeyAlias);
+    var alias = Statics.accountDnsSecKmsKeyAlias;
+    if (props.useSecondaryParameter) { // In auth-prod change the alias of the key so that another dnssec stack can sucssfully be deployed
+      alias += '/old';
+    }
+    const dnssecKey = this.addDNSSecKey(alias);
 
     // Store the key arn in a parameter for use in other projects
     //   (note that this parmeter is in us-east-1)


### PR DESCRIPTION
Ik heb de KMS key alias over het hoofd gezien. Hierdoor is het uitrollen van de dnssec stack gefaald. 
Oplossing: Ik hernoem de alias in auth-prod zodat de andere KMS key in de dnssec stack aangemaakt kan worden.