### PR TITLE
feat: deploy to dns root account

### DIFF
--- a/src/DnsRootStack.ts
+++ b/src/DnsRootStack.ts
@@ -62,7 +62,7 @@ export class DnsRootStack extends cdk.Stack {
   }
 
   setupDnsManagementRole() {
-    const role = new IAM.Role(this, 'role', {
+    const role = new IAM.Role(this, 'dns-management-role', {
       roleName: 'dns-manager',
       description: 'Role for dns-management account with access rights to IAM (readonly) and Route53',
       assumedBy: new IAM.PrincipalWithConditions(

--- a/src/DnsRootStack.ts
+++ b/src/DnsRootStack.ts
@@ -38,6 +38,9 @@ export class DnsRootStack extends cdk.Stack {
     // Set DS records for subdomains
     this.createDsRecords();
 
+    // Configure SES for sending mails from @nijmegen.nl
+    this.setupMailRecords();
+
     /**
      * Temporarely we have to add the existing csp-nijmegen.nl records
      * This ensures we can switch dns without downtime.
@@ -57,10 +60,141 @@ export class DnsRootStack extends cdk.Stack {
       recordName: 'auth-prod',
       values: ['60066 13 2 0E517A7669408AFC5345B167EBEBC3BB0D355E48FF160EBCF46EF27189C49949'],
     });
+    new Route53.DsRecord(this, 'accp-ds-record', {
+      zone: this.cspNijmegenZone,
+      recordName: 'accp',
+      values: ['52561 13 2 07CCC7D1A28A7BF1F221F50589AF606FD807B1793F28B0D76AF7F56D32FDE0FE'],
+    });
   }
 
   temporarelyAddExistingCspNijmegenRecords() {
-    // TODO: add records
+
+    // Good to know but also present in accp.csp-nijmegen.nl hosted zone
+    // accp.csp-nijmegen.nl	TXT	Simple	-	"v=spf1 include:amazonses.com ~all"
+    // accp.csp-nijmegen.nl	MX	Simple	- 10 feedback-smtp.eu-west-1.amazonses.com
+
+    // Not relevant i think (literal slashes in there)
+    // mail.csp-nijmegen.nl	TXT	Simple	-	"\"v=spf1 include:amazonses.com ~all\""
+
+    // NOTE: A and AAAA records must be configured manually!
+
+    // TEMP records mijn nijmegen
+    new Route53.DsRecord(this, 'mijn-nijmegen-ds', {
+      zone: this.cspNijmegenZone,
+      recordName: 'mijn',
+      values: ['60066 13 2 932CD585B029E674E17C4C33DFE7DE2C84353ACD8C109760FD17A6CDBD0CF3FA'],
+    });
+    new Route53.NsRecord(this, 'mijn-nijmegen-ds', {
+      zone: this.cspNijmegenZone,
+      recordName: 'mijn',
+      values: [
+        'ns-674.awsdns-20.net',
+        'ns-1880.awsdns-43.co.uk',
+        'ns-1091.awsdns-08.org',
+        'ns-160.awsdns-20.com',
+      ],
+    });
+
+    // Other records
+    new Route53.TxtRecord(this, 'temp-cdn-txt', { // I have no clue what this does
+      zone: this.cspNijmegenZone,
+      recordName: 'cdn',
+      values: ['9c5ca9b585a61a66c590a3ca912f9283511a286fc26978596059445f5795ebb7'],
+    });
+
+    // CNAME records for validation of certificates (all temporarely added, after moving there is no certificate required on the csp-nijmegen.nl hosted zone)
+    new Route53.CnameRecord(this, 'temp-cname-1', {
+      zone: this.cspNijmegenZone,
+      recordName: '_859607f90d21b7dc4baefd691342ff37',
+      domainName: 'eacbeb67b92c42efa3bfb148a847be8c.682b5c12a9f4cdf42dde19f6323900ee.comodoca.com.',
+    });
+    new Route53.CnameRecord(this, 'temp-cname-2', {
+      zone: this.cspNijmegenZone,
+      recordName: '_fe679386e9d233d59f58a9cb7d00ca77',
+      domainName: '03eb57d71e04544096bac14ce41431fa.058306850a8780ce3af8d4347102606b.comodoca.com.',
+    });
+    new Route53.CnameRecord(this, 'temp-cname-3', {
+      zone: this.cspNijmegenZone,
+      recordName: '_0736ae35ae9c4de52bdda1852b93fd97.alb-formio',
+      domainName: '_4b83e395676256e35d7d3d782ac5f5d8.lkwmzfhcjn.acm-validations.aws.',
+    });
+    new Route53.CnameRecord(this, 'temp-cname-4', {
+      zone: this.cspNijmegenZone,
+      recordName: '_9aeaaf089312840a908a88ab54b9914b.alb',
+      domainName: '_38d1a3dc7ab5b98cbb944586028d1c01.jddtvkljgg.acm-validations.aws.',
+    });
+    new Route53.CnameRecord(this, 'temp-cname-5', {
+      zone: this.cspNijmegenZone,
+      recordName: '_008c62eff4b4faa7b2a9b93c9a0fd53a.cdn',
+      domainName: '_8d01b287e916ee0865c45e4f2514795c.tjxrvlrcqj.acm-validations.aws.',
+    });
+    new Route53.CnameRecord(this, 'temp-cname-6', {
+      zone: this.cspNijmegenZone,
+      recordName: '_024e218687efee4c3949009da5c08e6c.eform-api',
+      domainName: '_18422c3cf53ae7e6fc96ba7cc7fdbff4.cnsgthfrdk.acm-validations.aws.',
+    });
+    new Route53.CnameRecord(this, 'temp-cname-7', {
+      zone: this.cspNijmegenZone,
+      recordName: '_c72e8bcdc9bcdc77647bd4a3bdb8b72f.form-dashboard',
+      domainName: '_a33d4c3d036e55abd1d45dfa7fc3b5b5.jddtvkljgg.acm-validations.aws.',
+    });
+    new Route53.CnameRecord(this, 'temp-cname-8', {
+      zone: this.cspNijmegenZone,
+      recordName: '_641e70643a9dd52155bb11983bd3c734.form',
+      domainName: '_095fc2806eb36160acdb32ef0665bd17.jddtvkljgg.acm-validations.aws.',
+    });
+
+
+  }
+
+  setupMailRecords() {
+    new Route53.CnameRecord(this, 'mail-dkim-1', {
+      zone: this.cspNijmegenZone,
+      recordName: 'p2qzrb7orqvnmcbfteuitb6rcm7ppjeg._domainkey',
+      domainName: 'p2qzrb7orqvnmcbfteuitb6rcm7ppjeg.dkim.amazonses.com',
+    });
+    new Route53.CnameRecord(this, 'mail-dkim-2', {
+      zone: this.cspNijmegenZone,
+      recordName: '3oauc4kfqwgwdmd7sqyj66r4lwx52gbd._domainkey',
+      domainName: '3oauc4kfqwgwdmd7sqyj66r4lwx52gbd.dkim.amazonses.com',
+    });
+    new Route53.CnameRecord(this, 'mail-dkim-3', {
+      zone: this.cspNijmegenZone,
+      recordName: 'jscft5y6jlalacyyubloeajrxeaezfbb._domainkey',
+      domainName: 'jscft5y6jlalacyyubloeajrxeaezfbb.dkim.amazonses.com',
+    });
+
+    new Route53.MxRecord(this, 'mail-mx', {
+      zone: this.cspNijmegenZone,
+      recordName: 'mail',
+      values: [{
+        priority: 10,
+        hostName: 'feedback-smtp.eu-west-1.amazonses.com',
+      }],
+    });
+    new Route53.TxtRecord(this, 'mail-txt', {
+      zone: this.cspNijmegenZone,
+      recordName: 'mail',
+      values: ['v=spf1 include:amazonses.com ~all'],
+    });
+
+    // Probably old records?
+    // new Route53.CnameRecord(this, 'mail-dkim-4', {
+    //   zone: this.cspNijmegenZone,
+    //   recordName: 'cnc3stfudnfqpna7j6a3lcgahiwwckio._domainkey',
+    //   domainName: 'cnc3stfudnfqpna7j6a3lcgahiwwckio.dkim.amazonses.com',
+    // });
+    // new Route53.CnameRecord(this, 'mail-dkim-5', {
+    //   zone: this.cspNijmegenZone,
+    //   recordName: 'db7i6gsrpjmp7ng7zw7dmyej7hkxvzvu._domainkey',
+    //   domainName: 'db7i6gsrpjmp7ng7zw7dmyej7hkxvzvu.dkim.amazonses.com',
+    // });
+    // new Route53.CnameRecord(this, 'mail-dkim-6', {
+    //   zone: this.cspNijmegenZone,
+    //   recordName: 'nv3xyzt6klljngnmf5yp6gb7tyjyj2xf._domainkey',
+    //   domainName: 'nv3xyzt6klljngnmf5yp6gb7tyjyj2xf.dkim.amazonses.com',
+    // });
+
   }
 
 

--- a/src/DnsRootStack.ts
+++ b/src/DnsRootStack.ts
@@ -102,7 +102,7 @@ export class DnsRootStack extends cdk.Stack {
           'iam:List*',
         ],
         resources: [
-          '*',
+          `arn:aws:iam::${this.account}:role/csp-nijmegen-delegation-*`,
         ],
       }),
     );

--- a/src/DnsRootStack.ts
+++ b/src/DnsRootStack.ts
@@ -53,7 +53,7 @@ export class DnsRootStack extends cdk.Stack {
 
   }
 
-  setupDnsManagementRole(){
+  setupDnsManagementRole() {
     const role = new IAM.Role(this, 'role', {
       roleName: 'dns-manager',
       description: 'Role for dns-management account with access rights to IAM (readonly) and Route53',
@@ -67,16 +67,36 @@ export class DnsRootStack extends cdk.Stack {
       ),
     });
 
+    /**
+     * Policy for route53
+     */
     role.addToPolicy(
       new IAM.PolicyStatement({
         effect: IAM.Effect.ALLOW,
         actions: [
           'route53:*', // Allow domain management
           'route53domains:*', // Allow domain management
+        ],
+        resources: [
+          '*',
+        ],
+      }),
+    );
+
+    /**
+     * Policy for iam
+     */
+    role.addToPolicy(
+      new IAM.PolicyStatement({
+        effect: IAM.Effect.ALLOW,
+        actions: [
           'iam:Get*',
           'iam:List*',
-        ]
-      })
+        ],
+        resources: [
+          '*',
+        ],
+      }),
     );
 
     new SSM.StringParameter(this, 'dns-manager-role-arn', {
@@ -121,7 +141,7 @@ export class DnsRootStack extends cdk.Stack {
       recordName: 'mijn',
       values: ['60066 13 2 932CD585B029E674E17C4C33DFE7DE2C84353ACD8C109760FD17A6CDBD0CF3FA'],
     });
-    new Route53.NsRecord(this, 'mijn-nijmegen-ds', {
+    new Route53.NsRecord(this, 'mijn-nijmegen-ns', {
       zone: this.cspNijmegenZone,
       recordName: 'mijn',
       values: [

--- a/src/DnsRootStack.ts
+++ b/src/DnsRootStack.ts
@@ -24,7 +24,15 @@ export class DnsRootStack extends cdk.Stack {
       zoneName: 'csp-nijmegen.nl',
     });
 
-    // Note: no need to export the zoneName and zoneId as ssm parameters for now.
+    // Export hostedzone properties for importing in the dnssec stack
+    new SSM.StringParameter(this, 'csp-sub-hostedzone-id', {
+      stringValue: this.cspNijmegenZone.hostedZoneId,
+      parameterName: Statics.envRootHostedZoneId,
+    });
+    new SSM.StringParameter(this, 'csp-sub-hostedzone-name', {
+      stringValue: this.cspNijmegenZone.zoneName,
+      parameterName: Statics.envRootHostedZoneName,
+    });
 
     /**
      * To allow accounts to creat a subdomain in the root zone we use the

--- a/src/DnsRootStage.ts
+++ b/src/DnsRootStage.ts
@@ -16,6 +16,7 @@ export class DnsRootStage extends Stage {
     });
 
     new DnsSecStack(this, 'dnssec-stack', {
+      env: { region: 'us-east-1' },
       enableDnsSec: true,
     });
 

--- a/src/DnsRootStage.ts
+++ b/src/DnsRootStage.ts
@@ -1,6 +1,7 @@
 import { Environment, Stage, StageProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { DnsRootStack } from './DnsRootStack';
+import { DnsSecStack } from './DnsSecStack';
 
 export interface DnsRootStageProps extends StageProps {
   dnsRootAccount: Environment;
@@ -10,8 +11,12 @@ export class DnsRootStage extends Stage {
   constructor(scope: Construct, id: string, props: DnsRootStageProps) {
     super(scope, id, props);
 
-    new DnsRootStack(this, 'stack', {
+    new DnsRootStack(this, 'dns-stack', {
       env: props.dnsRootAccount,
+    });
+
+    new DnsSecStack(this, 'dnssec-stack', {
+      enableDnsSec: true,
     });
 
   }

--- a/src/PipelineStack.ts
+++ b/src/PipelineStack.ts
@@ -2,6 +2,7 @@ import { Stack, StackProps, Tags, pipelines } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { AccountStage } from './AccountStage';
 import { CspNijmegenStage } from './CspNijmegenStage';
+import { DnsRootStage } from './DnsRootStage';
 import { Statics } from './Statics';
 import { TempAuthAccpStage } from './TempAuthAccpStage';
 
@@ -23,11 +24,11 @@ export class PipelineStack extends Stack {
 
     const pipeline = this.pipeline();
 
-    // Wait for DNS account to be created
-    // const dnsRoot = new DnsRootStage(this, 'dns-management', {
-    //   env: Statics.dnsRootEnvironment,
-    //   dnsRootAccount: Statics.dnsRootEnvironment,
-    // });
+    // DNS root account
+    const dnsRoot = new DnsRootStage(this, 'dns-management', {
+      env: Statics.dnsRootEnvironment,
+      dnsRootAccount: Statics.dnsRootEnvironment,
+    });
 
     // Can be removed after the csp-nijmegen.nl zone is in use in the new dns account
     const cspStage = new CspNijmegenStage(this, 'dns-management-root', {
@@ -75,6 +76,7 @@ export class PipelineStack extends Stack {
 
     // Setup the pipeline
     pipeline.addStage(cspStage);
+    pipeline.addStage(dnsRoot);
     const wave = pipeline.addWave('accounts');
     wave.addStage(sandboxStage);
     wave.addStage(authAccpStage);

--- a/src/Statics.ts
+++ b/src/Statics.ts
@@ -28,8 +28,8 @@ export class Statics {
   /**
    * IAM Account related stuff
    */
-   static readonly iamAccountId: string = '098799052470';
-   static readonly ssmDnsManagerRoleArn: string = '/cdk/dns-management/manager-role-arn';
+  static readonly iamAccountId: string = '098799052470';
+  static readonly ssmDnsManagerRoleArn: string = '/cdk/dns-management/manager-role-arn';
 
   /**
    * Environments
@@ -57,7 +57,7 @@ export class Statics {
   static readonly dnsRootEnvironment = {
     account: '108197740505',
     region: 'eu-west-1',
-  }
+  };
 
 
   /**

--- a/src/Statics.ts
+++ b/src/Statics.ts
@@ -25,6 +25,11 @@ export class Statics {
    */
   static readonly codeStarConnectionArn: string = 'arn:aws:codestar-connections:eu-west-1:418648875085:connection/4f647929-c982-4f30-94f4-24ff7dbf9766';
 
+  /**
+   * IAM Account related stuff
+   */
+   static readonly iamAccountId: string = '098799052470';
+   static readonly ssmDnsManagerRoleArn: string = '/cdk/dns-management/manager-role-arn';
 
   /**
    * Environments
@@ -48,6 +53,11 @@ export class Statics {
     account: '315037222840',
     region: 'eu-west-1',
   };
+
+  static readonly dnsRootEnvironment = {
+    account: '108197740505',
+    region: 'eu-west-1',
+  }
 
 
   /**

--- a/src/constructs/DnsManagementRole.ts
+++ b/src/constructs/DnsManagementRole.ts
@@ -1,0 +1,111 @@
+import {
+  aws_iam as IAM,
+  aws_ssm as SSM,
+  Stack,
+} from 'aws-cdk-lib';
+import { NagSuppressions } from 'cdk-nag';
+import { Construct } from 'constructs';
+import { Statics } from '../Statics';
+
+export class DnsManagementRole extends Construct {
+
+  constructor(scope: Stack, id: string) {
+    super(scope, id);
+
+    const role = new IAM.Role(this, 'dns-management-role', {
+      roleName: 'dns-manager',
+      description: 'Role for dns-management account with access rights to IAM (readonly) and Route53',
+      assumedBy: new IAM.PrincipalWithConditions(
+        new IAM.AccountPrincipal(Statics.iamAccountId), //IAM account
+        {
+          Bool: {
+            'aws:MultiFactorAuthPresent': true,
+          },
+        },
+      ),
+    });
+
+    /**
+         * Policy for route53 and route53domains
+         * Allows the role to manage dns hosted zones and domain names in this account.
+         */
+    const dnsManagemntPolicy = new IAM.PolicyStatement({
+      effect: IAM.Effect.ALLOW,
+      actions: [
+        'route53:*', // Allow domain management
+        'route53domains:*', // Allow domain management
+      ],
+      resources: [
+        '*',
+      ],
+    });
+    role.addToPolicy(dnsManagemntPolicy);
+
+    /**
+         * Readonly policy for IAM
+         * This policy allows this role to view the csp-nijmegen-delegation-* roles which
+         * are created in the DnsRootStack for using CrossAccountZoneDelegation constructs
+         * from route53.
+         */
+    const iamPolicy = new IAM.PolicyStatement({
+      effect: IAM.Effect.ALLOW,
+      actions: [
+        'iam:Get*',
+        'iam:List*',
+      ],
+      resources: [
+        `arn:aws:iam::${scope.account}:role/csp-nijmegen-delegation-*`,
+      ],
+    });
+    role.addToPolicy(iamPolicy);
+
+    /**
+         * Policy for kms
+         * Allows this role to view KMS keys in this account, this is relevant for dns managment
+         * because a KMS key is used to create a DNSSEC KSK.
+         */
+    const kmsPolicy = new IAM.PolicyStatement({
+      effect: IAM.Effect.ALLOW,
+      actions: [
+        'kms:Get*',
+        'kms:List*',
+        'kms:DescribeCustomKeyStores',
+        'kms:DescribeKey',
+      ],
+      resources: [
+        '*',
+      ],
+    });
+    role.addToPolicy(kmsPolicy);
+
+
+    NagSuppressions.addResourceSuppressions(
+      role,
+      [
+        {
+          id: 'AwsSolutions-IAM5',
+          reason: 'De IAM policy is beperkt to het inzien van IAM rollen t.b.v. de CrossAccountZoneDelgation roles.',
+          appliesTo: ['Action::iam:Get*', 'Action::iam:List*', 'Resource::arn:aws:iam::<AWS::AccountId>:role/csp-nijmegen-delegation-*'],
+        },
+        {
+          id: 'AwsSolutions-IAM5',
+          reason: 'De rol mag wel route53(domains) managen om zo dns management mogelijk te maken. Route53 domains ondersteunt geen resources dus een wildcard is nodig https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazonroute53domains.html',
+          appliesTo: ['Resource::*', 'Action::route53domains:*', 'Action::route53:*'],
+        },
+        {
+          id: 'AwsSolutions-IAM5',
+          reason: 'De KMS policy is beperkt tot het inzein van KMS keys.',
+          appliesTo: ['Resource::*', 'Action::kms:Get*', 'Action::kms:List*'],
+        },
+      ],
+      true,
+    );
+
+    new SSM.StringParameter(this, 'dns-manager-role-arn', {
+      parameterName: Statics.ssmDnsManagerRoleArn,
+      stringValue: role.roleArn,
+    });
+
+  }
+
+}

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -60,8 +60,14 @@ function checkNagStack(stack: Stack) {
     };
   });
 
-  console.warn(JSON.stringify(ws, null, 4));
-  console.error(JSON.stringify(es, null, 4));
+  if (ws && ws.length > 0) {
+    console.warn('Warnings in stack ', stack.stackName);
+    console.warn(JSON.stringify(ws, null, 4));
+  }
+  if (es && es.length > 0) {
+    console.error('Errors in stack ', stack.stackName);
+    console.error(JSON.stringify(es, null, 4));
+  }
 
   expect(warnings).toHaveLength(0);
   expect(errors).toHaveLength(0);


### PR DESCRIPTION
Deploy the DnsRootStack and a DnsSecStack to the dns account (#57).
This includes:
- Mail dns records for csp-nijmegen.nl
- Validation records for certificates
- NS and DS records 
- Other records (not sure what they are used for but we want to keep them and sort that out later)