### PR TITLE
feat: move auth-prod hosted zone to new csp-nijmegen.nl hosted zone

### DIFF
--- a/src/PipelineStack.ts
+++ b/src/PipelineStack.ts
@@ -62,7 +62,7 @@ export class PipelineStack extends Stack {
     const authProdStage = new AccountStage(this, 'dns-management-auth-prod', {
       env: Statics.authProdEnvironment,
       name: 'auth-prod',
-      dnsRootEnvironment: Statics.authProdEnvironment,
+      dnsRootEnvironment: Statics.dnsRootEnvironment,
       deployDnsStack: true,
       enableDnsSec: true,
       deployDnsSecKmsKey: true,


### PR DESCRIPTION
Nu eerst auth-prod, dit omdat deze zone wel wordt aangemaakt en er dingen aan vast hangen, maar nog niet in gebruik is.