### PR TITLE
feat: deploy dns subodmain to test-2 account

### DIFF
--- a/src/DnsRootStack.ts
+++ b/src/DnsRootStack.ts
@@ -47,6 +47,7 @@ export class DnsRootStack extends cdk.Stack {
     this.enableDelegationToAccount(arn, Statics.authProdEnvironment, 'auth-prod');
     this.enableDelegationToAccount(arn, Statics.generiekAccpEnvironment, 'generiek-accp');
     this.enableDelegationToAccount(arn, Statics.generiekProdEnvironment, 'generiek-prod');
+    this.enableDelegationToAccount(arn, Statics.test2Environment, 'test-2');
 
     // Set DS records for subdomains
     this.createDsRecords();

--- a/src/PipelineStack.ts
+++ b/src/PipelineStack.ts
@@ -84,6 +84,17 @@ export class PipelineStack extends Stack {
       registerInCspNijmegenRoot: true,
     });
 
+    // TEST-2 (upgrade webformulieren)
+    const test2Stage = new AccountStage(this, 'dns-management-test-2', {
+      env: Statics.test2Environment,
+      name: 'test-2',
+      dnsRootEnvironment: Statics.dnsRootEnvironment,
+      deployDnsStack: true,
+      enableDnsSec: true,
+      deployDnsSecKmsKey: true,
+      registerInCspNijmegenRoot: true,
+    });
+
     const authAccpRecordStage = new AuthAccpStage(this, 'dns-management-acceptance-records', {
       env: Statics.authAccpEnvironment,
     });
@@ -96,6 +107,7 @@ export class PipelineStack extends Stack {
     wave.addStage(authProdStage);
     wave.addStage(generiekAccpStage);
     wave.addStage(generiekProdStage);
+    wave.addStage(test2Stage);
 
     // Set mail records in accp.csp-nijmegen.nl
     pipeline.addStage(authAccpRecordStage);

--- a/src/Statics.ts
+++ b/src/Statics.ts
@@ -69,6 +69,11 @@ export class Statics {
     region: 'eu-west-1',
   };
 
+  static readonly test2Environment = {
+    account: '374828078457',
+    region: 'eu-west-1',
+  };
+
   /**
    * Create a role name (used for registration and assuming the role)
    * @param name


### PR DESCRIPTION
- allows delegation for test-2 subdomain to test-2 account
- Deploy account stage with dnssec and dns stack