### PR TITLE
fix: stage name property is unintentionally pickedup after cdk update

### DIFF
--- a/src/DnsConfiguration.ts
+++ b/src/DnsConfiguration.ts
@@ -14,7 +14,7 @@ export interface AccountConfiguration {
    * Acceptance stage had a different name than the name field in this interface
    * Therefore allow to override the stage name using this property
    */
-  stageName?: string;
+  overwriteStageName?: string;
 }
 
 export const DnsConfiguration: AccountConfiguration[] = [
@@ -34,7 +34,7 @@ export const DnsConfiguration: AccountConfiguration[] = [
     enableDnsSec: true,
     deployDnsSecKmsKey: true,
     registerInCspNijmegenRoot: true,
-    stageName: 'acceptance',
+    overwriteStageName: 'acceptance',
   }, {
     environment: Statics.authProdEnvironment,
     name: 'auth-prod',
@@ -51,7 +51,7 @@ export const DnsConfiguration: AccountConfiguration[] = [
     enableDnsSec: false,
     deployDnsSecKmsKey: false,
     registerInCspNijmegenRoot: true,
-    stageName: 'genriek-accp',
+    overwriteStageName: 'genriek-accp',
   }, {
     environment: Statics.generiekProdEnvironment,
     name: 'generiek-prod',
@@ -60,7 +60,7 @@ export const DnsConfiguration: AccountConfiguration[] = [
     enableDnsSec: false,
     deployDnsSecKmsKey: false,
     registerInCspNijmegenRoot: true,
-    stageName: 'genriek-prod',
+    overwriteStageName: 'genriek-prod',
   }, {
     environment: Statics.test2Environment,
     name: 'test-2',

--- a/src/PipelineStack.ts
+++ b/src/PipelineStack.ts
@@ -36,7 +36,7 @@ export class PipelineStack extends Stack {
     // Account stages
     const wave = pipeline.addWave('accounts');
     props.dnsConfiguration.forEach(acc => {
-      const stageName = acc.stageName ?? acc.name;
+      const stageName = acc.overwriteStageName ?? acc.name;
       const stage = new AccountStage(this, `dns-management-${stageName}`, {
         env: acc.environment,
         ...acc,

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -39,7 +39,7 @@ test('Snapshot', () => {
         environment: dummyEnv,
         name: 'snapshot-subdomain',
         registerInCspNijmegenRoot: true,
-        stageName: 'override-name-for-logicalid',
+        overwriteStageName: 'override-name-for-logicalid',
       },
     ],
   });
@@ -107,7 +107,7 @@ test('Snapshot pipeline', () => {
       environment: dummyEnv,
       name: 'snapshot-subdomain',
       registerInCspNijmegenRoot: true,
-      stageName: 'override-name-for-logicalid',
+      overwriteStageName: 'override-name-for-logicalid',
     }],
   });
   expect(app.synth().getStackArtifact(pipeline.artifactId).template).toMatchSnapshot();
@@ -121,7 +121,7 @@ test('Snapshot with actual dns configuration', () => {
   const stages: AccountStage[] = [];
 
   DnsConfiguration.forEach(acc => {
-    const stageName = acc.stageName ?? acc.name;
+    const stageName = acc.overwriteStageName ?? acc.name;
     const stage = new AccountStage(app, `snapshot-dns-management-${stageName}`, {
       env: acc.environment,
       ...acc,


### PR DESCRIPTION
Gekke change in de CDK zorgt ervoor dat de stageName property nu wordt opgepakt uit het configuratie object dat als StageProps wordt gebruikt. Dat was niet de bedoeling, de stage name is zo ineens veranderd.