### PR TITLE
feat: prepare for parallel deployment in new LZ

### DIFF
--- a/src/AccountStage.ts
+++ b/src/AccountStage.ts
@@ -36,9 +36,13 @@ export class AccountStage extends Stage {
 
     // KMS key used for dnssec (must be in us-east-1)
     if (props.deployDnsSecKmsKey) {
+      if (props.dnsRootEnvironment.region == undefined) {
+        throw 'Region reference to csp root hosted zone account is empty, can not deploy dnssec stack.';
+      }
       this.dnssecStack = new DnsSecStack(this, 'dnssec-stack', {
         env: { region: 'us-east-1' },
         enableDnsSec: props.enableDnsSec,
+        lookupHostedZoneInRegion: props.dnsRootEnvironment.region,
       });
     }
 

--- a/src/Configuration.ts
+++ b/src/Configuration.ts
@@ -1,0 +1,80 @@
+import { AccountConfiguration, DnsConfigurationExistingLz, DnsConfigurationNewLz } from './DnsConfiguration';
+import { Statics } from './Statics';
+
+/**
+ * Custom Environment with obligatory accountId and region
+ */
+export interface Environment {
+  account: string;
+  region: string;
+}
+
+export interface Configuration {
+
+  /**
+   * The Git branch for which this configuration is applicable
+   */
+  branchName: string;
+
+  /**
+   * The code star connection arn to use in the deployment account
+   */
+  codeStartConnectionArn: string;
+
+  /**
+   * Deployment account (gemeentenijmegen-deployment/gn-build)
+   */
+  deploymentEnvironment: Environment;
+
+  /**
+   * DNS root environment (e.g. the dns account)
+   */
+  dnsRootEnvironment: Environment;
+
+  /**
+   * A list of accounts to configure
+   */
+  dnsConfiguration: AccountConfiguration[];
+
+  /**
+   * CNAME records to add
+   * Note: do not add csp-nijmegen.nl suffix (route53 will add this for us).
+   */
+  cnameRecords?: { [key: string]: string };
+
+  /**
+   * DS records to add
+   * Note: do not add csp-nijmegen.nl suffix (route53 will add this for us).
+   */
+  dsRecords?: { [key: string]: string };
+}
+
+export interface Configurable {
+  configuration : Configuration;
+}
+
+export const configurations: { [key: string]: Configuration } = {
+  production: {
+    branchName: 'production',
+    codeStartConnectionArn: Statics.codeStarConnectionArn,
+    deploymentEnvironment: Statics.deploymentEnvironment,
+    dnsRootEnvironment: Statics.dnsRootEnvironment,
+    dnsConfiguration: DnsConfigurationExistingLz,
+  },
+  main: {
+    branchName: 'main',
+    codeStartConnectionArn: Statics.codeStarConnectionArnNewLz,
+    deploymentEnvironment: Statics.gnBuildEnvironment,
+    dnsRootEnvironment: Statics.gnNetworkEnvironment,
+    dnsConfiguration: DnsConfigurationNewLz,
+  },
+};
+
+
+export function getConfiguration(buildBranch: string) {
+  const config = configurations[buildBranch];
+  if (!config) {
+    throw Error(`No configuration for branch ${buildBranch} found. Add a configuration in Configuration.ts`);
+  }
+  return config;
+}

--- a/src/DnsConfiguration.ts
+++ b/src/DnsConfiguration.ts
@@ -17,7 +17,7 @@ export interface AccountConfiguration {
   overwriteStageName?: string;
 }
 
-export const DnsConfiguration: AccountConfiguration[] = [
+export const DnsConfigurationExistingLz: AccountConfiguration[] = [
   {
     environment: Statics.sandboxEnvironment,
     name: 'sandbox',
@@ -95,3 +95,6 @@ export const DnsConfiguration: AccountConfiguration[] = [
     registerInCspNijmegenRoot: true,
   },
 ];
+
+
+export const DnsConfigurationNewLz: AccountConfiguration[] = [];

--- a/src/DnsRootStage.ts
+++ b/src/DnsRootStage.ts
@@ -1,26 +1,24 @@
-import { Environment, Stage, StageProps } from 'aws-cdk-lib';
+import { Stage, StageProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
-import { AccountConfiguration } from './DnsConfiguration';
+import { Configurable } from './Configuration';
 import { DnsRootStack } from './DnsRootStack';
 import { DnsSecStack } from './DnsSecStack';
 
-export interface DnsRootStageProps extends StageProps {
-  dnsRootAccount: Environment;
-  dnsConfiguration: AccountConfiguration[];
-}
+export interface DnsRootStageProps extends StageProps, Configurable {}
 
 export class DnsRootStage extends Stage {
   constructor(scope: Construct, id: string, props: DnsRootStageProps) {
     super(scope, id, props);
 
     new DnsRootStack(this, 'dns-stack', {
-      env: props.dnsRootAccount,
-      dnsConfiguration: props.dnsConfiguration,
+      env: props.configuration.dnsRootEnvironment,
+      configuration: props.configuration,
     });
 
     new DnsSecStack(this, 'dnssec-stack', {
       env: { region: 'us-east-1' },
       enableDnsSec: true,
+      lookupHostedZoneInRegion: props.configuration.dnsRootEnvironment.region,
     });
 
   }

--- a/src/DnsSecStack.ts
+++ b/src/DnsSecStack.ts
@@ -11,6 +11,8 @@ export interface DnsSecStackProps extends cdk.StackProps {
    * set this to true to import the account hosted zone and enable dnssec on it
    */
   enableDnsSec: boolean;
+
+  lookupHostedZoneInRegion: string;
 }
 
 export class DnsSecStack extends cdk.Stack {
@@ -32,7 +34,7 @@ export class DnsSecStack extends cdk.Stack {
     });
 
     if (props.enableDnsSec) {
-      this.enableDnsSecForAccountRootZone(dnssecKey.keyArn);
+      this.enableDnsSecForAccountRootZone(dnssecKey.keyArn, props);
     }
 
   }
@@ -41,12 +43,12 @@ export class DnsSecStack extends cdk.Stack {
    * Enable DNSSEC usign the KMS key from this stack for the account root hosted zone.
    * @param keyArn
    */
-  enableDnsSecForAccountRootZone(keyArn: string) {
+  enableDnsSecForAccountRootZone(keyArn: string, props: DnsSecStackProps) {
 
     // Import the hosted zone id from eu-west-1
     const parameters = new RemoteParameters(this, 'hosted-zone-parameters', {
       path: Statics.envRootHostedZonePath,
-      region: 'eu-west-1',
+      region: props.lookupHostedZoneInRegion,
     });
     this.suppressNaggingRemoteParameters(parameters);
     const hostedZoneId = parameters.get(Statics.envRootHostedZoneId);

--- a/src/Statics.ts
+++ b/src/Statics.ts
@@ -24,6 +24,7 @@ export class Statics {
    * Code star connection to github
    */
   static readonly codeStarConnectionArn: string = 'arn:aws:codestar-connections:eu-west-1:418648875085:connection/4f647929-c982-4f30-94f4-24ff7dbf9766';
+  static readonly codeStarConnectionArnNewLz: string = 'arn:aws:codestar-connections:eu-central-1:836443378780:connection/9d20671d-91bc-49e2-8680-59ff96e2ab11';
 
   /**
    * IAM Account related stuff
@@ -88,6 +89,19 @@ export class Statics {
     account: '698929623502',
     region: 'eu-west-1',
   };
+
+  // New LZ
+  static readonly gnBuildEnvironment = {
+    account: '836443378780',
+    region: 'eu-central-1',
+  };
+
+  // New LZ
+  static readonly gnNetworkEnvironment = {
+    account: '043872078922',
+    region: 'eu-central-1',
+  };
+
 
   /**
    * Create a role name (used for registration and assuming the role)

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,14 +1,16 @@
 import { App } from 'aws-cdk-lib';
-import { DnsConfiguration } from './DnsConfiguration';
+import { getConfiguration } from './Configuration';
 import { PipelineStack } from './PipelineStack';
-import { Statics } from './Statics';
 
+// Get configuration
+const buildBranch = process.env.BRANCH_NAME ?? 'production';
+console.log('Building branch', buildBranch);
+const configuration = getConfiguration(buildBranch);
+
+// Build the CDK app
 const app = new App();
-
 new PipelineStack(app, 'dns-management-pipeline', {
-  env: Statics.deploymentEnvironment,
-  branchName: 'production',
-  dnsConfiguration: DnsConfiguration,
+  env: configuration.deploymentEnvironment,
+  configuration: configuration,
 });
-
 app.synth();


### PR DESCRIPTION
- Added configuration based on branch name
- Added new way to deploy DNS records to the root hosted zone
- Only deploy current CNAME and DS records when on production branch
- Configured `main` branch to be used for the new LZ